### PR TITLE
Remove module admin route explicit method

### DIFF
--- a/Config/routing.xml
+++ b/Config/routing.xml
@@ -2,7 +2,7 @@
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="popin.config" path="/admin/module/PopIn" methods="get">
+    <route id="popin.config" path="/admin/module/PopIn">
         <default key="_controller">PopIn:Configuration:config</default>
     </route>
     <route id="popin.pop_in_campaign.create" path="/admin/module/PopIn/pop_in_campaign" methods="post">


### PR DESCRIPTION
Causes an issue when listing modules for translation.

Fixes https://github.com/thelia-modules/PopIn/issues/1
